### PR TITLE
Add SandboxConfig copy constructor with stdio kwargs

### DIFF
--- a/src/SandboxConfig.jl
+++ b/src/SandboxConfig.jl
@@ -135,7 +135,18 @@ struct SandboxConfig
 
         return new(mounts, env, entrypoint, pwd, persist, collect(multiarch_formats), Cint(uid), Cint(gid), tmpfs_size, hostname, stdin, stdout, stderr, verbose)
     end
+
+    # Inner constructor that takes an existing SandboxConfig and allows modifying stdio
+    function SandboxConfig(config::SandboxConfig;
+                           stdin::AnyRedirectable = config.stdin,
+                           stdout::AnyRedirectable = config.stdout,
+                           stderr::AnyRedirectable = config.stderr)
+        return new(config.mounts, config.env, config.entrypoint, config.pwd,
+                   config.persist, config.multiarch_formats, config.uid, config.gid,
+                   config.tmpfs_size, config.hostname, stdin, stdout, stderr, config.verbose)
+    end
 end
+
 
 # Compatibility shim for `read_only_maps`/`read_write_maps` API:
 function SandboxConfig(read_only_maps::Dict{String,String},


### PR DESCRIPTION
This adds an inner constructor to SandboxConfig that takes an existing SandboxConfig instance and allows modifying the stdio streams (stdin, stdout, stderr) via keyword arguments while preserving all other fields.

This is useful when you need to create a modified copy of a SandboxConfig with different IO redirections without having to manually copy all fields.

🤖 Generated with [Claude Code](https://claude.ai/code)