### PR TITLE
Allow specifying `CmdRedirect` as user command

### DIFF
--- a/src/Docker.jl
+++ b/src/Docker.jl
@@ -141,6 +141,13 @@ function commit_previous_run(exe::DockerExecutor, image_name::String)
     return image_name
 end
 
+function build_executor_command(exe::DockerExecutor, config::SandboxConfig, user_cmd::Base.CmdRedirect)
+    if user_cmd.stream_no > 2
+        error("DockerExecutor does not support redirection of streams other than stdin, stdout, and stderr")
+    end
+    return Base.CmdRedirect(build_executor_command(exe, confi, user_cmd.cmd), user_cmd.handle, user_cmd.stream_no, user_cmd.readable)
+end
+
 function build_executor_command(exe::DockerExecutor, config::SandboxConfig, user_cmd::Cmd)
     # Build the docker image that corresponds to this rootfs
     image_name = build_docker_image(config.mounts, config.uid, config.gid; verbose=config.verbose)

--- a/src/UserNamespaces.jl
+++ b/src/UserNamespaces.jl
@@ -135,6 +135,10 @@ function check_overlayfs_loaded(;verbose::Bool = false)
     return true
 end
 
+function build_executor_command(exe::UserNamespacesExecutor, config::SandboxConfig, user_cmd::Base.CmdRedirect)
+    return Base.CmdRedirect(build_executor_command(exe, config, user_cmd.cmd), user_cmd.handle, user_cmd.stream_no, user_cmd.readable)
+end
+
 function build_executor_command(exe::UserNamespacesExecutor, config::SandboxConfig, user_cmd::Cmd)
     # While we would usually prefer to use the `executable_product()` function to get a
     # `Cmd` object that has all of the `PATH` and `LD_LIBRARY_PATH` environment variables

--- a/test/UserNamespaces.jl
+++ b/test/UserNamespaces.jl
@@ -94,6 +94,15 @@ if executor_available(UnprivilegedUserNamespacesExecutor)
             @test String(take!(stdout)) == "received SIGINT\nreceived SIGTERM\n"
         end
     end
+
+    @testset "Extra fds" begin
+        config = SandboxConfig(Dict("/" => Sandbox.debian_rootfs()))
+        with_executor(UnprivilegedUserNamespacesExecutor) do exe
+            buf = IOBuffer()
+            @test success(exe, config, Base.CmdRedirect(`/bin/sh -c "echo hello >&3"`, buf, 3))
+            @test String(take!(buf)) == "hello\n"
+        end
+    end
 else
     @error("Skipping Unprivileged tests, as it does not seem to be available")
 end


### PR DESCRIPTION
If specified they will override the global stdio config. A primary motivation is to pass non-stdio fds, cf
https://github.com/JuliaLang/julia/commit/79a5ccd237dbed05dd8f85c4e948656ebf76eb48.